### PR TITLE
Set "thread name" for worker threads.

### DIFF
--- a/src/bbcp_File.C
+++ b/src/bbcp_File.C
@@ -304,7 +304,8 @@ int bbcp_File::Read_All(bbcp_BuffPool &inPool, int Vn)
    if (bbcp_Cfg.csOpts & bbcp_csVerIn)
       {csP = new bbcp_FileChkSum(&inPool, this, bbcp_Cfg.csType,
                                  bbcp_Cfg.csOpts & bbcp_csVerIO);
-       if ((rc = bbcp_Thread_Start(bbcp_FileCSX, (void *)csP, &tid)) < 0)
+       if ((rc = bbcp_Thread_Start(bbcp_FileCSX, "bbcp_FileCSX", (void *)csP,
+                                   &tid)) < 0)
            {bbcp_Emsg("File", rc, "starting file checksum thread.");
             delete csP;
             if (rtCopy) bbcp_RTCopy.Stop();
@@ -674,7 +675,8 @@ int bbcp_File::Write_All(bbcp_BuffPool &inPool, int nstrms)
       {csP = new bbcp_FileChkSum(&inPool, this, csType,
                                  bbcp_Cfg.csOpts & bbcp_csVerIO,nstrms);
        nstrms = 1;
-       if ((rc = bbcp_Thread_Start(bbcp_FileCSY, (void *)csP, &tid)) < 0)
+       if ((rc = bbcp_Thread_Start(bbcp_FileCSY, "bbcp_FileCSY", (void *)csP,
+                                   &tid)) < 0)
            {bbcp_Emsg("File", rc, "starting file checksum thread.");
             if (csP) delete csP;
             if (IOB) IOB->Close();

--- a/src/bbcp_LogFile.C
+++ b/src/bbcp_LogFile.C
@@ -133,7 +133,8 @@ void bbcp_LogFile::Monitor(int fdnum, char *fdname)
 
 // Start a log file thread (we loose storage upon failure)
 //
-   if ((retc = bbcp_Thread_Run(bbcp_FileLog, (void *)lrP, &(lrP->LogT))))
+   if ((retc = bbcp_Thread_Run(bbcp_FileLog, "bbcp_FileLog", (void *)lrP,
+                               &(lrP->LogT))))
       {bbcp_Emsg("LogFile", errno, "start logging thread to", Logfn);
        return;
       }

--- a/src/bbcp_Node.C
+++ b/src/bbcp_Node.C
@@ -440,7 +440,7 @@ int bbcp_Node::RecvFile(bbcp_FileSpec *fp, bbcp_Node *Remote)
 // Start a thread for each data link we have
 //
    for (i = 0; i < dlcount; i++)
-       {if ((retc = bbcp_Thread_Start(bbcp_Net2Buff, 
+       {if ((retc = bbcp_Thread_Start(bbcp_Net2Buff, "bbcp_Net2Buff",
                                 (void *)data_link[i], &tid))<0)
            {bbcp_Emsg("RecvFile",retc,"starting net thread for",Path);
             _exit(100);
@@ -453,7 +453,8 @@ int bbcp_Node::RecvFile(bbcp_FileSpec *fp, bbcp_Node *Remote)
 //
    if (bbcp_Cfg.Options & bbcp_COMPRESS)
       {seqFile = new bbcp_File(Path, 0, 0);
-       if ((retc = bbcp_Thread_Start(bbcp_doWrite, (void *)seqFile, &tid))<0)
+       if ((retc = bbcp_Thread_Start(bbcp_doWrite, "bbcp_doWrite",
+                                     (void *)seqFile, &tid))<0)
           {bbcp_Emsg("RecvFile",retc,"starting disk thread for",Path);
            _exit(100);
           }
@@ -615,7 +616,7 @@ int bbcp_Node::SendFile(bbcp_FileSpec *fp)
 // Start a thread for each data link we have
 //
    for (i = 0; i < dlcount; i++)
-       {if ((retc = bbcp_Thread_Start(bbcp_Buff2Net, 
+       {if ((retc = bbcp_Thread_Start(bbcp_Buff2Net, "bbcp_Buff2Net",
                                 (void *)data_link[i], &tid))<0)
            {bbcp_Emsg("SendFile",retc,"starting net thread for",fp->pathname);
             _exit(100);
@@ -774,7 +775,8 @@ int bbcp_Node::Outgoing(bbcp_Protocol *protocol)
        // Start threads for data connections
        //
        for (i = 0; i < bbcp_Cfg.Streams; i++)
-           {if ((retc=bbcp_Thread_Start(bbcp_Connect,(void *)protocol,&tid))<0)
+           {if ((retc=bbcp_Thread_Start(bbcp_Connect,"bbcp_Connect",
+                                        (void *)protocol,&tid))<0)
                {bbcp_Emsg("Outgoing", retc, "starting connect thread");
                 _exit(100);
                }
@@ -897,7 +899,7 @@ bbcp_ZCX *bbcp_Node::setup_CX(int deflating, int iofd)
 
 // Start the compression/expansion thread
 //
-   if ((retc = bbcp_Thread_Start(bbcp_doCX, (void *)cxp, &tid))<0)
+   if ((retc = bbcp_Thread_Start(bbcp_doCX, "bbcp_doCX", (void *)cxp, &tid))<0)
       {bbcp_Emsg("File", retc, "starting", 
                  (char *)(deflating ? "compression" : "expansion"),
                  (char *)" thread.");

--- a/src/bbcp_ProcMon.C
+++ b/src/bbcp_ProcMon.C
@@ -130,7 +130,8 @@ void bbcp_ProcMon::Start(pid_t monit, bbcp_Node *Remote)
 
 // Run a thread to start the monitor
 //
-   if ((retc = bbcp_Thread_Run(bbcp_MonProc, (void *)this, &mytid)))
+   if ((retc = bbcp_Thread_Run(bbcp_MonProc, "bbcp_MonProc", (void *)this,
+                               &mytid)))
       {DEBUG("Error " <<retc <<" starting MonProc thread.");}
       else {DEBUG("Thread " <<mytid <<" monitoring process " <<monPID);}
    return;
@@ -152,7 +153,8 @@ void bbcp_ProcMon::Start(int seclim, bbcp_BuffPool *buffpool)
 
 // Run a thread to start the monitor
 //
-   if ((retc = bbcp_Thread_Run(bbcp_MonProc, (void *)this, &mytid)))
+   if ((retc = bbcp_Thread_Run(bbcp_MonProc, "bbcp_MonProc", (void *)this,
+                               &mytid)))
       {DEBUG("Error " <<retc <<" starting buffpool monitor thread.");}
       else {DEBUG("Thread " <<mytid <<" monitoring buffpool.");}
    return;

--- a/src/bbcp_ProgMon.C
+++ b/src/bbcp_ProgMon.C
@@ -145,7 +145,8 @@ void bbcp_ProgMon::Start(bbcp_File *fs_obj, bbcp_ZCX *cx_obj, int pint,
 
 // Run a thread to start the monitor
 //
-   if ((retc = bbcp_Thread_Run(bbcp_MonProg, (void *)this, &mytid)))
+   if ((retc = bbcp_Thread_Run(bbcp_MonProg, "bbcp_MonProg", (void *)this,
+                               &mytid)))
       {DEBUG("Error " <<retc <<" starting progress monitor thread.");}
       else {DEBUG("Thread " <<mytid <<" monitoring progress.");}
    return;

--- a/src/bbcp_Protocol.C
+++ b/src/bbcp_Protocol.C
@@ -309,7 +309,8 @@ int bbcp_Protocol::Process(bbcp_Node *Node)
 // This avoids time-outs when large number of files are enumerated.
 //
    if (!NoGo && bbcp_Cfg.Options & bbcp_RECURSE)
-      if ((rc = bbcp_Thread_Start(bbcp_FileSpecIndex, 0, &Tid)) < 0)
+      if ((rc = bbcp_Thread_Start(bbcp_FileSpecIndex, "bbcp_FileSpecIndex", 0,
+                                  &Tid)) < 0)
          {bbcp_Emsg("Protocol", rc, "starting file enumeration thread.");
           NoGo = 1;
          }

--- a/src/bbcp_Pthread.C
+++ b/src/bbcp_Pthread.C
@@ -195,8 +195,9 @@ int bbcp_Thread_CanType(int Async)
 int bbcp_Thread_Detach(pthread_t tid)
     {return pthread_detach(tid);}
 
-int  bbcp_Thread_Run(void *(*proc)(void *), void *arg, pthread_t *tid)
-     {int retc = bbcp_Thread_Start(proc, arg, tid);
+int  bbcp_Thread_Run(void *(*proc)(void *), const char *name, void *arg,
+                     pthread_t *tid)
+     {int retc = bbcp_Thread_Start(proc, name, arg, tid);
       if (!retc) pthread_detach(*tid);
       return retc;
      }
@@ -206,8 +207,10 @@ int bbcp_Thread_Signal(pthread_t tid, int snum)
      return pthread_kill(tid, snum);
     }
 
-int  bbcp_Thread_Start(void *(*proc)(void *), void *arg, pthread_t *tid)
+int  bbcp_Thread_Start(void *(*proc)(void *), const char *name, void *arg,
+                       pthread_t *tid)
      {int rc = pthread_create(tid, NULL, proc, arg);
+      if (!rc) pthread_setname_np(*tid, name);
       return (rc ? -rc : 0);
      }
 

--- a/src/bbcp_Pthread.h
+++ b/src/bbcp_Pthread.h
@@ -174,9 +174,11 @@ int   bbcp_Thread_Cancel(pthread_t tid);
 int   bbcp_Thread_CanType(int Async);
 int   bbcp_Thread_Detach(pthread_t tid);
 void  bbcp_Thread_MT(int mtlvl);
-int   bbcp_Thread_Run(  void *(*proc)(void *), void *arg, pthread_t *tid);
+int   bbcp_Thread_Run(  void *(*proc)(void *), const char *name, void *arg,
+                        pthread_t *tid);
 int   bbcp_Thread_Signal(pthread_t tid, int snum);
-int   bbcp_Thread_Start(void *(*proc)(void *), void *arg, pthread_t *tid);
+int   bbcp_Thread_Start(void *(*proc)(void *), const char *name, void *arg,
+                        pthread_t *tid);
 void *bbcp_Thread_Wait(pthread_t tid);
 }
 #endif

--- a/src/bbcp_RTCopy.C
+++ b/src/bbcp_RTCopy.C
@@ -209,7 +209,8 @@ int bbcp_RTCopy::Start(bbcp_FileSystem *fsp, const char *iofn, int iofd)
 
 // Now start a thread that will try to obtain a shared lock
 //
-   if ((rc = bbcp_Thread_Run(bbcp_RTCopyLK, (void *)&xSem, &Tid)) < 0)
+   if ((rc = bbcp_Thread_Run(bbcp_RTCopyLK, "bbcp_RTCopyLK", (void *)&xSem,
+                             &Tid)) < 0)
       {bbcp_Emsg("RTCopy", rc, "starting file r/t lock thread.");
        Grow = -rc;
        return 0;


### PR DESCRIPTION
When looking at CPU usage for individual threads (eg. in 'ps H'), this helps identify threads and find bottlenecks.